### PR TITLE
[JENKINS-65161] Remove digester taken from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
         </pluginRepository>
     </pluginRepositories>
     
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-digester3</artifactId>
+            <version>3.2</version>
+        </dependency>
+    </dependencies>
     <scm>
     <connection>scm:git:git://github.com/jenkinsci/javatest-report-plugin</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/javatest-report-plugin.git</developerConnection>

--- a/src/main/java/hudson/plugins/javatest_report/Report.java
+++ b/src/main/java/hudson/plugins/javatest_report/Report.java
@@ -20,9 +20,10 @@
 package hudson.plugins.javatest_report;
 
 import hudson.model.AbstractBuild;
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 
@@ -63,7 +64,7 @@ public final class Report extends TestCollection<Report,Suite> {
      * Loads SQE report file into this {@link Report} object.
      */
     public void add( File reportXml ) throws IOException, SAXException {
-        Digester digester = new Digester();
+        Digester digester = createDigester(!Boolean.getBoolean(getClass().getName() + ".UNSAFE"));
         digester.setClassLoader(getClass().getClassLoader());
 
         digester.push(this);
@@ -93,4 +94,21 @@ public final class Report extends TestCollection<Report,Suite> {
     public String getChildTitle() {
         return "Test Suite";
     }
+
+    private Digester createDigester(boolean secure) throws SAXException {
+        Digester digester = new Digester();
+        if (secure) {
+            digester.setXIncludeAware(false);
+            try {
+                digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                digester.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                digester.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                digester.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            } catch (ParserConfigurationException ex) {
+                throw new SAXException("Failed to securely configure xml digester parser", ex);
+            }
+        }
+        return digester;
+    }
+    
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This is a follow up PR for jenkinsci/jenkins#5320 tracked by issues.jenkins.io/browse/JENKINS-65161

We're removing Digester from Jenkins core because it's not used there. This PR adds Digester to this plugin and builds the object to parse xmls safely.

Maintainer: @lvotypko
Additional reviewers: @olamy @alecharp @rsandell @car-roll @bitwiseman @jtnord 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
